### PR TITLE
Modified tsconfig.json to include 'forceConsistentCasingInFileNames' flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "express-model-validation",
   "author": "Marc Means",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "dependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "diagnostics": false,
+    "forceConsistentCasingInFileNames": true,
     "listFiles": true,
     "module": "commonjs",
     "noImplicitAny": false,


### PR DESCRIPTION
The 'forceConsistentCasingInFileNames' flag disallows inconsistently-cased references to the same file.  This can prevent casing issues when build succeed in a Windows environment, but fail in a *nix environment because of filename casing on imports.